### PR TITLE
deps: remove unused seek_bufread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,6 @@ dependencies = [
  "hex",
  "log",
  "rusty-leveldb",
- "seek_bufread",
  "tempfile",
 ]
 
@@ -545,12 +544,6 @@ checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "seek_bufread"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a248bca144497822c75e8a12d26b7c0bfd9240fc4baa0b2f64f81619ddd58d"
 
 [[package]]
 name = "snap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ env_logger = "0.10.0"
 hex = "0.4.3"
 log = { version = "0.4.19", default-features = false, features = ["std"] }
 rusty-leveldb = "2.0.0"
-seek_bufread = "1.2.2"
 
 [dev-dependencies]
 tempfile =  "3.7.0"

--- a/src/parser/blkfile.rs
+++ b/src/parser/blkfile.rs
@@ -4,7 +4,6 @@ use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use seek_bufread::BufReader;
 
 use crate::parser::reader::BlockchainRead;
 
@@ -13,7 +12,7 @@ use crate::parser::reader::BlockchainRead;
 pub struct BlkFile {
     pub path: PathBuf,
     pub size: u64,
-    reader: Option<BufReader<File>>,
+    reader: Option<std::io::BufReader<File>>,
 }
 
 impl BlkFile {
@@ -26,10 +25,10 @@ impl BlkFile {
     }
 
     /// Opens the file handle (does nothing if the file has been opened already)
-    fn open(&mut self) -> anyhow::Result<&mut BufReader<File>> {
+    fn open(&mut self) -> anyhow::Result<&mut std::io::BufReader<File>> {
         if self.reader.is_none() {
             log::debug!(target: "blkfile", "Opening {} ...", &self.path.display());
-            self.reader = Some(BufReader::new(File::open(&self.path)?));
+            self.reader = Some(std::io::BufReader::new(File::open(&self.path)?));
         }
         Ok(self.reader.as_mut().unwrap())
     }

--- a/src/parser/reader.rs
+++ b/src/parser/reader.rs
@@ -15,7 +15,6 @@ impl<R: std::io::Read + ?Sized> BlockchainRead for R {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use seek_bufread::BufReader;
 
     #[test]
     fn test_bitcoin_parse_genesis_block() {
@@ -80,7 +79,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x0,
         ];
         let inner = std::io::Cursor::new(raw_data);
-        let mut reader = BufReader::with_capacity(200, inner);
+        let mut reader = std::io::BufReader::with_capacity(200, inner);
 
         // Parse block
         let block = reader.read_block().unwrap();


### PR DESCRIPTION
The std::io variant is entirely sufficient.