### PR TITLE
deps: remove minimally useful byteorder crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,6 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitcoin",
- "byteorder",
  "clap",
  "dirs",
  "hex",
@@ -133,12 +132,6 @@ name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.72"
 bitcoin = "0.30.1"
-byteorder = "1.4.3"
 clap = { version = "4.3.19", features = [ "cargo" ] }
 dirs = "5.0.1"
 hex = "0.4.3"

--- a/src/parser/index.rs
+++ b/src/parser/index.rs
@@ -1,6 +1,7 @@
+use std::io::Read;
+
 use bitcoin::hashes::{sha256d, Hash};
 
-use byteorder::ReadBytesExt;
 use rusty_leveldb::{LdbIterator, Options, DB};
 
 use crate::ParserOptions;
@@ -153,7 +154,9 @@ fn is_block_index_record(data: &[u8]) -> bool {
 fn read_varint(reader: &mut std::io::Cursor<&[u8]>) -> anyhow::Result<u64> {
     let mut n = 0;
     loop {
-        let ch_data = reader.read_u8()?;
+        let mut buf = [0; 1];
+        reader.read_exact(&mut buf)?;
+        let ch_data = buf[0];
         assert!(n <= u64::MAX >> 7, "size too large");
         n = (n << 7) | u64::from(ch_data & 0x7F);
         if ch_data & 0x80 > 0 {


### PR DESCRIPTION
As its documentation details [1], the `u8` variant is only included for completeness becuase there is byteorder associated with reading a single byte.

Instead of pulling in a dependency, inline the
implementation of `read_u8()`.