### PR TITLE
tests: replicate data instead of synchronizing access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,6 @@ dependencies = [
  "clap",
  "dirs",
  "hex",
- "once_cell",
  "rusty-leveldb",
  "tempfile",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ tracing-subscriber = { version = "0.3.17", features = [ "env-filter", "fmt", "an
 
 [dev-dependencies]
 hex = "0.4.3"
-once_cell = "1.18.0"
 tempfile =  "3.7.0"

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -1,12 +1,12 @@
 mod common;
 
-static STORAGE: once_cell::sync::Lazy<
-    std::sync::Mutex<bitcoin_blockparser::parser::chain::ChainStorage>,
-> = once_cell::sync::Lazy::new(|| std::sync::Mutex::new(common::storage("bitcoin", 170)));
+fn storage() -> bitcoin_blockparser::parser::chain::ChainStorage {
+    common::storage("bitcoin", 170)
+}
 
 #[test]
 fn test_bitcoin_genesis() {
-    let genesis = STORAGE.lock().unwrap().get_block(0).unwrap();
+    let genesis = storage().get_block(0).unwrap();
     assert_eq!(
         genesis,
         bitcoin::blockdata::constants::genesis_block(bitcoin::network::constants::Network::Bitcoin)
@@ -76,7 +76,7 @@ fn test_bitcoin_genesis() {
 
 #[test]
 fn test_genesis_header() {
-    let header = STORAGE.lock().unwrap().get_header(0).unwrap();
+    let header = storage().get_header(0).unwrap();
     assert_eq!(
         header,
         bitcoin::blockdata::constants::genesis_block(bitcoin::network::constants::Network::Bitcoin)
@@ -86,11 +86,12 @@ fn test_genesis_header() {
 
 #[test]
 fn test_blockdata_parsing() {
+    let mut storage = storage();
     for height in 0..=169 {
-        let block = STORAGE.lock().unwrap().get_block(height).unwrap();
+        let block = storage.get_block(height).unwrap();
         assert_eq!(block.txdata.len(), 1);
     }
-    let first_tx_block = STORAGE.lock().unwrap().get_block(170).unwrap();
+    let first_tx_block = storage.get_block(170).unwrap();
     assert_eq!(first_tx_block.txdata.len(), 2);
 
     let tx = first_tx_block.txdata.get(1).unwrap();
@@ -105,7 +106,8 @@ fn test_blockdata_parsing() {
 
 #[test]
 fn test_timing() {
+    let mut storage = storage();
     for height in 0..=169 {
-        STORAGE.lock().unwrap().get_header(height).unwrap();
+        storage.get_header(height).unwrap();
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,16 +1,28 @@
+fn copy_dir_all(
+    src: impl AsRef<std::path::Path>,
+    dst: impl AsRef<std::path::Path>,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(&dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
 pub fn storage(datadir: &str, max_height: u64) -> bitcoin_blockparser::parser::chain::ChainStorage {
+    let tempdir = tempfile::tempdir().unwrap();
+    copy_dir_all(format!("tests/testdata/{datadir}"), &tempdir).unwrap();
     let options = bitcoin_blockparser::ParserOptions {
         coin: datadir.parse().unwrap(),
         verify: true,
-        blockchain_dir: std::path::PathBuf::from(format!("tests/testdata/{datadir}")),
+        blockchain_dir: tempdir.into_path(),
         range: bitcoin_blockparser::BlockHeightRange::new(0, Some(max_height)).unwrap(),
     };
-    let storage = bitcoin_blockparser::parser::chain::ChainStorage::new(&options).unwrap();
-
-    // Discard transient diff on LevelDB files
-    std::process::Command::new("git")
-        .args(["checkout", format!("tests/testdata/{datadir}").as_str()])
-        .output()
-        .unwrap();
-    storage
+    bitcoin_blockparser::parser::chain::ChainStorage::new(&options).unwrap()
 }

--- a/tests/testnet3.rs
+++ b/tests/testnet3.rs
@@ -1,12 +1,13 @@
 mod common;
 
-static STORAGE: once_cell::sync::Lazy<
-    std::sync::Mutex<bitcoin_blockparser::parser::chain::ChainStorage>,
-> = once_cell::sync::Lazy::new(|| std::sync::Mutex::new(common::storage("testnet3", 120)));
+fn storage() -> bitcoin_blockparser::parser::chain::ChainStorage {
+    common::storage("testnet3", 120)
+}
 
 #[test]
 fn test_blockdata_parsing() {
-    let genesis = STORAGE.lock().unwrap().get_block(0).unwrap();
+    let mut storage = storage();
+    let genesis = storage.get_block(0).unwrap();
     assert_eq!(
         genesis,
         bitcoin::blockdata::constants::genesis_block(bitcoin::network::constants::Network::Testnet)
@@ -16,14 +17,15 @@ fn test_blockdata_parsing() {
         "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
     );
     for height in 0..=120 {
-        let block = STORAGE.lock().unwrap().get_block(height).unwrap();
+        let block = storage.get_block(height).unwrap();
         assert_eq!(block.txdata.len(), 1);
     }
 }
 
 #[test]
 fn test_genesis_header() {
-    let header = STORAGE.lock().unwrap().get_header(0).unwrap();
+    let mut storage = storage();
+    let header = storage.get_header(0).unwrap();
     assert_eq!(
         header,
         bitcoin::blockdata::constants::genesis_block(bitcoin::network::constants::Network::Testnet)


### PR DESCRIPTION
In the future we also want to integration-test
the higher-level `BlockchainParser` struct, which
needs access to a proper `ChainStorage`. Our current approach of synchronizing access to a single one
would lead to problems there, as it is only
available behind a mutex guard.

To solve this, we replicate the test data into a
new tempdir for every test, which then has exclusive access. This also gets rid of the awkward Git
cleanup afterwards.