### PR TITLE
add initial block analysis to sqlite db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 csvdump
 
 **/LOG*
+**/*.db
+**/*.db-journal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +98,8 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "clap",
+ "diesel",
+ "diesel_migrations",
  "dirs",
  "hex",
  "rusty-leveldb",
@@ -189,6 +197,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
+name = "diesel"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+dependencies = [
+ "diesel_derives",
+ "libsqlite3-sys",
+ "r2d2",
+ "time",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +266,12 @@ dependencies = [
  "redox_users",
  "windows-sys",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -280,6 +344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +366,16 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "integer-encoding"
@@ -315,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,10 +413,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -352,6 +458,27 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "migrations_internals"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -382,10 +509,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c516611246607d0c04186886dbb3a754368ef82c79e9827a802c6d836dd111c"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -409,6 +565,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -553,6 +720,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +754,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +790,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "snap"
@@ -647,6 +864,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+dependencies = [
+ "deranged",
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +991,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasi"
@@ -812,3 +1097,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acaaa1190073b2b101e15083c38ee8ec891b5e05cbee516521e94ec008f61e64"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2021"
 anyhow = "1.0.72"
 bitcoin = "0.30.1"
 clap = { version = "4.3.21", features = [ "cargo" ] }
+diesel = { version = "2.1.0", features = [ "r2d2", "sqlite" ], default-features = false }
+diesel_migrations = "2.1.0"
 dirs = "5.0.1"
 rusty-leveldb = "2.0.0"
 tracing = { version = "0.1.37", default-features = false }

--- a/migrations/2023-08-09-202146_add_opreturn_table/down.sql
+++ b/migrations/2023-08-09-202146_add_opreturn_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE blocks;

--- a/migrations/2023-08-09-202146_add_opreturn_table/up.sql
+++ b/migrations/2023-08-09-202146_add_opreturn_table/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE blocks (
+    height INTEGER PRIMARY KEY NOT NULL,
+    version INTEGER NOT NULL,
+    time INTEGER NOT NULL,
+    encoded_target INTEGER NOT NULL,
+    nonce BIGINT NOT NULL,
+    tx_count INTEGER NOT NULL,
+    size INTEGER NOT NULL,
+    weight BIGINT NOT NULL
+);

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -1,0 +1,34 @@
+use diesel_migrations::MigrationHarness;
+
+pub type Pool =
+    diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<diesel::sqlite::SqliteConnection>>;
+
+pub trait Managed {
+    #[must_use]
+    fn open(db_url: &str, migrations: diesel_migrations::EmbeddedMigrations) -> Pool {
+        tracing::info!("opening in-memory database");
+        let db = memdb_pool(db_url);
+        create_tables(&db, migrations);
+        db
+    }
+}
+
+fn create_tables(pool: &Pool, migrations: diesel_migrations::EmbeddedMigrations) {
+    let conn = &mut pool.get().unwrap();
+    conn.run_pending_migrations(migrations)
+        .expect("Could not apply database migration");
+}
+
+#[must_use]
+fn memdb_pool(db_url: &str) -> Pool {
+    let manager = diesel::r2d2::ConnectionManager::<diesel::sqlite::SqliteConnection>::new(db_url);
+    let forever = Some(std::time::Duration::from_secs(u64::MAX));
+    diesel::r2d2::Pool::builder()
+        .idle_timeout(forever)
+        .max_lifetime(forever)
+        .connection_timeout(std::time::Duration::from_secs(5))
+        .build(manager)
+        .expect("Problem creating connection pool")
+}
+
+impl Managed for Pool {}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,52 @@
+use self::memory::Managed;
+use diesel::prelude::*;
+use diesel::RunQueryDsl;
+use schema::blocks;
+
+mod memory;
+pub mod schema;
+
+#[derive(Clone)]
+pub struct Db {
+    pub pool: memory::Pool,
+}
+
+#[derive(Debug, diesel::Selectable, diesel::Queryable, diesel::Insertable)]
+pub struct Block {
+    pub height: i32,
+    pub version: i32,
+    pub time: i32,
+    pub encoded_target: i32,
+    pub nonce: i64,
+    pub tx_count: i32,
+    pub size: i32,
+    pub weight: i64,
+}
+
+const MIGRATIONS: diesel_migrations::EmbeddedMigrations = diesel_migrations::embed_migrations!();
+
+impl Db {
+    #[must_use]
+    pub fn open(db_url: &str) -> Self {
+        Self {
+            pool: memory::Pool::open(db_url, MIGRATIONS),
+        }
+    }
+
+    pub fn insert_block(&self, block: Block) -> anyhow::Result<usize> {
+        Ok(diesel::insert_into(blocks::table)
+            .values(block)
+            .execute(&mut self.pool.get()?)?)
+    }
+
+    pub fn block(&self, height: i32) -> anyhow::Result<Block> {
+        Ok(blocks::table
+            .select(Block::as_select())
+            .filter(blocks::height.eq(height))
+            .get_result(&mut self.pool.get()?)?)
+    }
+
+    pub fn blocks_count(&self) -> anyhow::Result<i64> {
+        Ok(blocks::table.count().get_result(&mut self.pool.get()?)?)
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,0 +1,14 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    blocks (height) {
+        height -> Integer,
+        version -> Integer,
+        time -> Integer,
+        encoded_target -> Integer,
+        nonce -> BigInt,
+        tx_count -> Integer,
+        size -> Integer,
+        weight -> BigInt,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ fn main() {
     };
 
     let mut parser = BlockchainParser::new(&options, chain_storage);
-    parser.start();
+    if let Err(e) = parser.start() {
+        tracing::error!("error: {e:?}");
+    }
     tracing::info!(target: "main", "Fin.");
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,8 @@
 use std::time::{Duration, Instant};
 
+use diesel::connection::TransactionManager;
+use diesel::RunQueryDsl;
+
 use crate::parser::chain::ChainStorage;
 use crate::ParserOptions;
 
@@ -29,6 +32,7 @@ pub struct BlockchainParser {
     chain_storage: ChainStorage,
     stats: WorkerStats,
     cur_height: u64,
+    db: crate::db::Db,
 }
 
 impl BlockchainParser {
@@ -39,21 +43,39 @@ impl BlockchainParser {
             chain_storage,
             stats: WorkerStats::new(options.range.start),
             cur_height: options.range.start,
+            db: crate::db::Db::open(&options.db_url),
         }
     }
 
-    pub fn start(&mut self) {
+    #[must_use]
+    pub fn db(&self) -> &crate::db::Db {
+        &self.db
+    }
+
+    pub fn start(&mut self) -> anyhow::Result<()> {
         tracing::debug!(target: "parser", "Starting worker ...");
 
         self.on_start(self.cur_height);
+        let mut conn = self.db.pool.get()?;
+        diesel::r2d2::PoolTransactionManager::begin_transaction(&mut conn)?;
         while let Some(header) = self.chain_storage.get_header(self.cur_height) {
             Self::on_header(&header, self.cur_height);
             let block = self.chain_storage.get_block(self.cur_height).unwrap();
-            Self::on_block(&block, self.cur_height);
+            self.on_block(&block, self.cur_height, &mut conn)?;
             self.print_progress(self.cur_height);
             self.cur_height += 1;
+
+            if self.cur_height % 1000 == 0 {
+                diesel::r2d2::PoolTransactionManager::commit_transaction(&mut conn)?;
+                drop(conn);
+                conn = self.db.pool.get()?;
+                diesel::r2d2::PoolTransactionManager::begin_transaction(&mut conn)?;
+            }
         }
+        diesel::r2d2::PoolTransactionManager::commit_transaction(&mut conn)?;
+        drop(conn);
         self.on_complete(self.cur_height.saturating_sub(1));
+        Ok(())
     }
 
     #[must_use]
@@ -75,8 +97,28 @@ impl BlockchainParser {
         tracing::trace!(target: "parser", "on_header(height={}) called", height);
     }
 
-    fn on_block(_block: &bitcoin::Block, height: u64) {
+    fn on_block(
+        &mut self,
+        block: &bitcoin::Block,
+        height: u64,
+        conn: &mut diesel::r2d2::PooledConnection<
+            diesel::r2d2::ConnectionManager<diesel::sqlite::SqliteConnection>,
+        >,
+    ) -> anyhow::Result<()> {
         tracing::trace!(target: "parser", "on_block(height={}) called", height);
+        diesel::insert_into(crate::db::schema::blocks::table)
+            .values(crate::db::Block {
+                height: self.cur_height.try_into()?,
+                version: block.header.version.to_consensus(),
+                time: block.header.time.try_into()?,
+                encoded_target: block.header.bits.to_consensus().try_into()?,
+                nonce: block.header.nonce.try_into()?,
+                tx_count: block.txdata.len().try_into()?,
+                size: block.size().try_into()?,
+                weight: block.weight().to_wu().try_into()?,
+            })
+            .execute(conn)?;
+        Ok(())
     }
 
     fn on_complete(&mut self, height: u64) {

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -4,6 +4,10 @@ fn storage() -> bitcoin_blockparser::parser::chain::ChainStorage {
     common::storage("bitcoin", 170)
 }
 
+fn parser() -> bitcoin_blockparser::parser::BlockchainParser {
+    common::parser("bitcoin", 170)
+}
+
 #[test]
 fn test_bitcoin_genesis() {
     let genesis = storage().get_block(0).unwrap();
@@ -110,4 +114,11 @@ fn test_timing() {
     for height in 0..=169 {
         storage.get_header(height).unwrap();
     }
+}
+
+#[test]
+fn test_blocks_db() {
+    let mut parser = parser();
+    parser.start().unwrap();
+    assert_eq!(parser.db().blocks_count().unwrap(), 171);
 }

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -109,7 +109,7 @@ fn test_blockdata_parsing() {
 }
 
 #[test]
-fn test_timing() {
+fn test_headers() {
     let mut storage = storage();
     for height in 0..=169 {
         storage.get_header(height).unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,10 +19,27 @@ pub fn storage(datadir: &str, max_height: u64) -> bitcoin_blockparser::parser::c
     let tempdir = tempfile::tempdir().unwrap();
     copy_dir_all(format!("tests/testdata/{datadir}"), &tempdir).unwrap();
     let options = bitcoin_blockparser::ParserOptions {
+        db_url: ":memory:".parse().unwrap(),
         coin: datadir.parse().unwrap(),
         verify: true,
         blockchain_dir: tempdir.into_path(),
         range: bitcoin_blockparser::BlockHeightRange::new(0, Some(max_height)).unwrap(),
     };
     bitcoin_blockparser::parser::chain::ChainStorage::new(&options).unwrap()
+}
+
+pub fn parser(datadir: &str, max_height: u64) -> bitcoin_blockparser::parser::BlockchainParser {
+    let tempdir = tempfile::tempdir().unwrap();
+    copy_dir_all(format!("tests/testdata/{datadir}"), &tempdir).unwrap();
+    let options = bitcoin_blockparser::ParserOptions {
+        db_url: ":memory:".parse().unwrap(),
+        coin: datadir.parse().unwrap(),
+        verify: true,
+        blockchain_dir: tempdir.into_path(),
+        range: bitcoin_blockparser::BlockHeightRange::new(0, Some(max_height)).unwrap(),
+    };
+    bitcoin_blockparser::parser::BlockchainParser::new(
+        &options,
+        bitcoin_blockparser::parser::chain::ChainStorage::new(&options).unwrap(),
+    )
 }

--- a/tests/testnet3.rs
+++ b/tests/testnet3.rs
@@ -4,6 +4,10 @@ fn storage() -> bitcoin_blockparser::parser::chain::ChainStorage {
     common::storage("testnet3", 120)
 }
 
+fn parser() -> bitcoin_blockparser::parser::BlockchainParser {
+    common::parser("testnet3", 120)
+}
+
 #[test]
 fn test_blockdata_parsing() {
     let mut storage = storage();
@@ -31,4 +35,11 @@ fn test_genesis_header() {
         bitcoin::blockdata::constants::genesis_block(bitcoin::network::constants::Network::Testnet)
             .header
     );
+}
+
+#[test]
+fn test_blocks_db() {
+    let mut parser = parser();
+    parser.start().unwrap();
+    assert_eq!(parser.db().blocks_count().unwrap(), 121);
 }


### PR DESCRIPTION
This commit introduces the new approach we
take towards local data analysis: build up
a database of pertinent information.

We start with some low-hanging fruit on
individual blocks.

The new DB logic supports sqlite for now,
both in in-memory mode for tests, and to
a DB file for persistence. No attempts are
made at recognizing existing data in an
existing DB.

As an optimization, we buffer 1000 blocks
before we commit data to the DB. This is
done in an admittedly hacky manner, to be
cleaned up later.